### PR TITLE
uuid-utils 0.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-
-upload_channels:
-  - sfe1ed40
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cargo-bundle-licenses
   host:
     - python
-    - maturin
+    - maturin >=1,<2
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,9 @@ test:
     - pytest
   requires:
     - pip
-    - pytest
+    - pytest -v tests  # [not osx]
+    # test_getnode is marked as xfail on linux but it seems doesn't work on macOS too.
+    - pytest -v tests -k "not test_getnode"  # [osx]
 
 about:
   home: https://github.com/aminalaee/uuid-utils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,9 @@ test:
     - pytest
   requires:
     - pip
-    - pytest -v tests  # [not osx]
+    - pytest tests  # [not osx]
     # test_getnode is marked as xfail on linux but it seems doesn't work on macOS too.
-    - pytest -v tests -k "not test_getnode"  # [osx]
+    - pytest tests -k "not test_getnode"  # [osx]
 
 about:
   home: https://github.com/aminalaee/uuid-utils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "uuid-utils" %}
-{% set version = "0.10.0" %}
+{% set version = "0.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,21 +7,19 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/uuid_utils-{{ version }}.tar.gz
-  sha256: 5db0e1890e8f008657ffe6ded4d9459af724ab114cfe82af1557c87545301539
+  sha256: 252bd3d311b5d6b7f5dfce7a5857e27bb4458f222586bb439463231e5a9cbd64
 
 build:
   number: 0
   skip: true  # [py<39]
-  missing_dso_whitelist:
-  - $RPATH/ld64.so.1  # [s390x]
   script:
     - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,14 +34,15 @@ test:
     - tests
   imports:
     - uuid_utils
-  commands:
-    - pip check
-    - pytest
   requires:
     - pip
-    - pytest # [not osx]
+    - pytest
+  commands:
+    - pip check
+    - pytest -v # [not osx]
     # test_getnode is marked as xfail on linux but it seems doesn't work on macOS too.
-    - pytest -k "not test_getnode"  # [osx]
+    - pytest -v -k "not test_getnode"  # [osx]
+
 
 about:
   home: https://github.com/aminalaee/uuid-utils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,9 @@ test:
     - pytest
   requires:
     - pip
-    - pytest tests  # [not osx]
+    - pytest # [not osx]
     # test_getnode is marked as xfail on linux but it seems doesn't work on macOS too.
-    - pytest tests -k "not test_getnode"  # [osx]
+    - pytest -k "not test_getnode"  # [osx]
 
 about:
   home: https://github.com/aminalaee/uuid-utils


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11765) 
- [Upstream repository](https://github.com/aminalaee/uuid-utils/tree/0.12.0)

### Explanation of changes:

- Remove the channel sfe1ed40 because this package is a dependency of langchain-core 1.2.6, see https://github.com/langchain-ai/langchain/blob/langchain-core%3D%3D1.2.6/libs/core/pyproject.toml#L22C6-L22C16
- Remove cxx_compiler
- Skip flaky `test_getnode` on osx.

### Notes:

-